### PR TITLE
fix for the DYNAMIC_LIB_COUNT bug

### DIFF
--- a/request_aad_prt/entry.c
+++ b/request_aad_prt/entry.c
@@ -3,10 +3,10 @@
 #include <winhttp.h>
 
 #ifdef BOF
-#define DYNAMIC_LIB_COUNT
-#include "beacon.h"
-#include "bofdefs.h"
-#include "base.c"
+#define DYNAMIC_LIB_COUNT 3
+#include "../common/beacon.h"
+#include "../common/bofdefs.h"
+#include "../common/base.c"
 #define MSVCRT$wcscpy ((wchar_t* (*)(wchar_t*, const wchar_t*))DynamicLoad("MSVCRT", "wcscpy"))
 #define MSVCRT$wcslen ((size_t (*)(const wchar_t*))DynamicLoad("MSVCRT", "wcslen"))
 #define MSVCRT$strstr ((char* (*)(const char*, const char*))DynamicLoad("MSVCRT", "strstr"))

--- a/request_aad_prt/requestaadprt.cna
+++ b/request_aad_prt/requestaadprt.cna
@@ -1,0 +1,14 @@
+beacon_command_register(
+	"requestaadprt",
+	"Request a Primary Refresh Token for Azure SSO",
+	"");
+
+alias requestaadprt{
+    $bof_handle = openf(script_resource("request_aad_prt.x64.o"));
+    $bof_data = readb($bof_handle, -1);
+    closef($bof_handle);
+
+    btask($1, "Tasking beacon to request Azure PRT");
+    beacon_inline_execute($1, $bof_data, "go", $args);
+
+}


### PR DESCRIPTION
BOF makes Cobalt Strike beacons to crash due to a VIOLATION ERROR which is caused by the lack of `DYNAMIC_LIB_COUNT `integer definition as shown in attached image. According to the docs of the TrustedSec library `DYNAMIC_LIB_COUNT `macro should count the number of libraries loaded with DynamicLoad.

<img width="1091" height="718" alt="image" src="https://github.com/user-attachments/assets/bce189d2-3fe9-415b-95ea-dd3a3525d15d" />


